### PR TITLE
Graphene django pr 563

### DIFF
--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -117,14 +117,19 @@ class DjangoConnectionField(ConnectionField):
         last = kwargs.get("last")
         if first is not None and first <= 0:
             raise ValueError(
-                "`first` argument must be positive, got `{first}`".format(first=first))
+                "`first` argument must be positive, got `{first}`".format(first=first)
+            )
         if last is not None and last <= 0:
             raise ValueError(
-                "`last` argument must be positive, got `{last}`".format(last=last))
+                "`last` argument must be positive, got `{last}`".format(last=last)
+            )
         if enforce_first_or_last and not (first or last):
             raise ValueError(
                 "You must provide a `first` or `last` value "
-                "to properly paginate the `{info.field_name}` connection.".format(info=info))
+                "to properly paginate the `{info.field_name}` connection.".format(
+                    info=info
+                )
+            )
 
         if max_limit:
             if first is None and last is None:

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -111,31 +111,42 @@ class DjangoConnectionField(ConnectionField):
         enforce_first_or_last,
         root,
         info,
-        **args
+        **kwargs
     ):
-        first = args.get("first")
-        last = args.get("last")
+        first = kwargs.get("first")
+        last = kwargs.get("last")
 
-        if enforce_first_or_last:
-            assert first or last, (
-                "You must provide a `first` or `last` value to properly paginate the `{}` connection."
-            ).format(info.field_name)
+        if not (first is None or first > 0):
+            raise ValueError(
+                "`first` argument must be positive, got `{first}`".format(**locals()))
+        if not (last is None or last > 0):
+            raise ValueError(
+                "`last` argument must be positive, got `{last}`".format(**locals()))
+
+        if enforce_first_or_last and not (first or last):
+            raise ValueError(
+                "You must provide a `first` or `last` value "
+                "to properly paginate the `{info.field_name}` connection.".format(**locals()))
 
         if max_limit:
             if first:
                 assert first <= max_limit, (
                     "Requesting {} records on the `{}` connection exceeds the `first` limit of {} records."
                 ).format(first, info.field_name, max_limit)
-                args["first"] = min(first, max_limit)
+                kwargs["first"] = min(first, max_limit)
 
             if last:
                 assert last <= max_limit, (
                     "Requesting {} records on the `{}` connection exceeds the `last` limit of {} records."
                 ).format(last, info.field_name, max_limit)
-                args["last"] = min(last, max_limit)
+                kwargs["last"] = min(last, max_limit)
 
-        iterable = resolver(root, info, **args)
-        on_resolve = partial(cls.resolve_connection, connection, default_manager, args)
+            if first is None and last is None:
+                kwargs['first'] = max_limit
+
+        iterable = resolver(root, info, **kwargs)
+        queryset = cls.resolve_queryset(connection, default_manager, info, kwargs)
+        on_resolve = partial(cls.resolve_connection, connection, queryset, kwargs)
 
         if Promise.is_thenable(iterable):
             return Promise.resolve(iterable).then(on_resolve)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -115,34 +115,27 @@ class DjangoConnectionField(ConnectionField):
     ):
         first = kwargs.get("first")
         last = kwargs.get("last")
-
-        if not (first is None or first > 0):
+        if first is not None and first <= 0:
             raise ValueError(
-                "`first` argument must be positive, got `{first}`".format(**locals()))
-        if not (last is None or last > 0):
+                "`first` argument must be positive, got `{first}`".format(first=first))
+        if last is not None and last <= 0:
             raise ValueError(
-                "`last` argument must be positive, got `{last}`".format(**locals()))
-
+                "`last` argument must be positive, got `{last}`".format(last=last))
         if enforce_first_or_last and not (first or last):
             raise ValueError(
                 "You must provide a `first` or `last` value "
-                "to properly paginate the `{info.field_name}` connection.".format(**locals()))
+                "to properly paginate the `{info.field_name}` connection.".format(info=info))
 
         if max_limit:
-            if first:
-                assert first <= max_limit, (
-                    "Requesting {} records on the `{}` connection exceeds the `first` limit of {} records."
-                ).format(first, info.field_name, max_limit)
-                kwargs["first"] = min(first, max_limit)
-
-            if last:
-                assert last <= max_limit, (
-                    "Requesting {} records on the `{}` connection exceeds the `last` limit of {} records."
-                ).format(last, info.field_name, max_limit)
-                kwargs["last"] = min(last, max_limit)
-
             if first is None and last is None:
                 kwargs['first'] = max_limit
+            else:
+                count = min(i for i in (first, last) if i)
+                if count > max_limit:
+                    raise ValueError(("Requesting {count} records "
+                                      "on the `{info.field_name}` connection "
+                                      "exceeds the limit of {max_limit} records.").format(
+                                          count=count, info=info, max_limit=max_limit))
 
         iterable = resolver(root, info, **kwargs)
         queryset = cls.resolve_queryset(connection, default_manager, info, kwargs)

--- a/graphene_django/fields.py
+++ b/graphene_django/fields.py
@@ -143,8 +143,7 @@ class DjangoConnectionField(ConnectionField):
                                           count=count, info=info, max_limit=max_limit))
 
         iterable = resolver(root, info, **kwargs)
-        queryset = cls.resolve_queryset(connection, default_manager, info, kwargs)
-        on_resolve = partial(cls.resolve_connection, connection, queryset, kwargs)
+        on_resolve = partial(cls.resolve_connection, connection, default_manager, kwargs)
 
         if Promise.is_thenable(iterable):
             return Promise.resolve(iterable).then(on_resolve)

--- a/graphene_django/filter/tests/test_fields.py
+++ b/graphene_django/filter/tests/test_fields.py
@@ -920,7 +920,6 @@ def test_filter_with_union():
         def resolve_all_reporters(cls, root, info, **kwargs):
             ret = Reporter.objects.none() | Reporter.objects.filter(first_name="John")
 
-
     Reporter.objects.create(first_name="John", last_name="Doe")
 
     schema = Schema(query=Query)

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -688,6 +688,137 @@ def test_should_not_error_if_last_and_first_not_greater_than_max():
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
 
 
+def test_should_error_if_negative_first():
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters(first: -100, last: 200) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": None}
+
+    result = schema.execute(query)
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "`first` argument must be positive, got `-100`"
+    assert result.data == expected
+
+
+def test_should_error_if_negative_last():
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters(first: 200, last: -100) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": None}
+
+    result = schema.execute(query)
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "`last` argument must be positive, got `-100`"
+    assert result.data == expected
+
+def test_max_limit_is_zero():
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 0
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    r = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
+    )
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters(first: 99999999) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": {"edges": [{"node": {"id": "UmVwb3J0ZXJUeXBlOjE="}}]}}
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected
+
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
+
+def test_max_limit_is_none():
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = None
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    r = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
+    )
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters(first: 99999999) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": {"edges": [{"node": {"id": "UmVwb3J0ZXJUeXBlOjE="}}]}}
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected
+
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
+
 def test_should_query_promise_connectionfields():
     from promise import Promise
 

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -1,21 +1,21 @@
 import datetime
 
+import graphene
 import pytest
 from django.db import models
-from django.utils.functional import SimpleLazyObject
-from py.test import raises
-
 from django.db.models import Q
 
 import graphene
+from django.utils.functional import SimpleLazyObject
 from graphene.relay import Node
+from py.test import raises
 
-from ..utils import DJANGO_FILTER_INSTALLED
-from ..compat import MissingType, JSONField
+from ..compat import JSONField, MissingType
 from ..fields import DjangoConnectionField
-from ..types import DjangoObjectType
 from ..settings import graphene_settings
-from .models import Article, CNNReporter, Reporter, Film, FilmDetails
+from ..types import DjangoObjectType
+from ..utils import DJANGO_FILTER_INSTALLED
+from .models import Article, CNNReporter, Film, FilmDetails, Reporter
 
 pytestmark = pytest.mark.django_db
 
@@ -603,7 +603,7 @@ def test_should_error_if_first_is_greater_than_max():
     assert len(result.errors) == 1
     assert str(result.errors[0]) == (
         "Requesting 101 records on the `allReporters` connection "
-        "exceeds the `first` limit of 100 records."
+        "exceeds the limit of 100 records."
     )
     assert result.data == expected
 
@@ -644,7 +644,7 @@ def test_should_error_if_last_is_greater_than_max():
     assert len(result.errors) == 1
     assert str(result.errors[0]) == (
         "Requesting 101 records on the `allReporters` connection "
-        "exceeds the `last` limit of 100 records."
+        "exceeds the limit of 100 records."
     )
     assert result.data == expected
 

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -747,6 +747,7 @@ def test_should_error_if_negative_last():
     assert str(result.errors[0]) == "`last` argument must be positive, got `-100`"
     assert result.data == expected
 
+
 def test_max_limit_is_zero():
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 0
 
@@ -783,6 +784,7 @@ def test_max_limit_is_zero():
 
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
 
+
 def test_max_limit_is_none():
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = None
 
@@ -818,6 +820,7 @@ def test_max_limit_is_none():
     assert result.data == expected
 
     graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
+
 
 def test_should_query_promise_connectionfields():
     from promise import Promise

--- a/graphene_django/tests/test_query.py
+++ b/graphene_django/tests/test_query.py
@@ -651,6 +651,43 @@ def test_should_error_if_last_is_greater_than_max():
     graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST = False
 
 
+def test_should_not_error_if_last_and_first_not_greater_than_max():
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 1
+
+    class ReporterType(DjangoObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    class Query(graphene.ObjectType):
+        all_reporters = DjangoConnectionField(ReporterType)
+
+    r = Reporter.objects.create(
+        first_name="John", last_name="Doe", email="johndoe@example.com", a_choice=1
+    )
+
+    schema = graphene.Schema(query=Query)
+    query = """
+        query NodeFilteringQuery {
+            allReporters(first: 999999, last: 1) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
+        }
+    """
+
+    expected = {"allReporters": {"edges": [{"node": {"id": "UmVwb3J0ZXJUeXBlOjE="}}]}}
+
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected
+
+    graphene_settings.RELAY_CONNECTION_MAX_LIMIT = 100
+
+
 def test_should_query_promise_connectionfields():
     from promise import Promise
 


### PR DESCRIPTION
This is a copy of graphql-python/graphene-django#563 that aims to support 'first' and 'last' with use of 'offset'. which solves this graphql-python/graphene-django#809 problem with using offset for pagination.

The changes I have made from the linked PR are:

Undo the unrelated formatting changes on migrations
Undo the shuffling around of imports
Clean up code formatting a bit